### PR TITLE
Robuster string parsing in bash script

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -13,4 +13,4 @@ if [ "$#" -lt 1 ]; then
 fi
 
 sudo -u $USER cargo build
-avrdude -q -C/etc/avrdude.conf -patmega328p -carduino -P/dev/ttyACM0 -D "-Uflash:w:$1:e"
+avrdude -q -C/etc/avrdude.conf -patmega328p -carduino -P/dev/ttyACM0 -D "-Uflash:w:${1}:e"


### PR DESCRIPTION
In the `avrdude` call the elf-file input argument is used:
`... -Uflash:w:$1:e`
On some systems `$1:e` is interpreted as the extension of this
argument, i.e. only producing `elf` instead of the full
`<path-to-elf.elf>`

Adding curly braces `${1]:e` ensures robust parsing.